### PR TITLE
release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## [1.0.0] - 2020-09-01 
 ### Added
-- initial version
+- initial version [#1](https://github.com/yuta1024/cards-moving-automation/pull/1) ([yuta1024](https://github.com/yuta1024))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Change log
+## [1.1.0] - 2020-09-27 [YANKED]
+### Added
+- output the log even if there are no cards to move [#12](https://github.com/yuta1024/cards-moving-automation/pull/12) ([yuta1024](https://github.com/yuta1024))
+- Add license scan report and status [#6](https://github.com/yuta1024/cards-moving-automation/pull/6) ([fossabot](https://github.com/fossabot))
+- add Codecov [#5](https://github.com/yuta1024/cards-moving-automation/pull/5) ([yuta1024](https://github.com/yuta1024))
+
+### Changed
+- Bump @actions/core from 1.2.5 to 1.2.6 [#11](https://github.com/yuta1024/cards-moving-automation/pull/11) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
+- Bump @vercel/ncc from 0.24.0 to 0.24.1 [#10](https://github.com/yuta1024/cards-moving-automation/pull/10) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
+- Bump eslint from 7.8.1 to 7.9.0 [#9](https://github.com/yuta1024/cards-moving-automation/pull/9) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
+- Bump eslint from 7.8.0 to 7.8.1 [#7](https://github.com/yuta1024/cards-moving-automation/pull/7) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
+- Bump eslint from 7.7.0 to 7.8.0 [#4](https://github.com/yuta1024/cards-moving-automation/pull/4) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
+- Bump @actions/core from 1.2.4 to 1.2.5 [#3](https://github.com/yuta1024/cards-moving-automation/pull/3) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
+- Bump @vercel/ncc from 0.23.0 to 0.24.0 [#2](https://github.com/yuta1024/cards-moving-automation/pull/2) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
+
+### Security
+- [Security] Bump node-fetch from 2.6.0 to 2.6.1 [#8](https://github.com/yuta1024/cards-moving-automation/pull/8) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
+
 
 ## [1.0.0] - 2020-09-01 
 ### Added


### PR DESCRIPTION
### Added
- output the log even if there are no cards to move [#12](https://github.com/yuta1024/cards-moving-automation/pull/12) ([yuta1024](https://github.com/yuta1024))
- Add license scan report and status [#6](https://github.com/yuta1024/cards-moving-automation/pull/6) ([fossabot](https://github.com/fossabot))
- add Codecov [#5](https://github.com/yuta1024/cards-moving-automation/pull/5) ([yuta1024](https://github.com/yuta1024))

### Changed
- Bump @actions/core from 1.2.5 to 1.2.6 [#11](https://github.com/yuta1024/cards-moving-automation/pull/11) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
- Bump @vercel/ncc from 0.24.0 to 0.24.1 [#10](https://github.com/yuta1024/cards-moving-automation/pull/10) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
- Bump eslint from 7.8.1 to 7.9.0 [#9](https://github.com/yuta1024/cards-moving-automation/pull/9) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
- Bump eslint from 7.8.0 to 7.8.1 [#7](https://github.com/yuta1024/cards-moving-automation/pull/7) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
- Bump eslint from 7.7.0 to 7.8.0 [#4](https://github.com/yuta1024/cards-moving-automation/pull/4) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
- Bump @actions/core from 1.2.4 to 1.2.5 [#3](https://github.com/yuta1024/cards-moving-automation/pull/3) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))
- Bump @vercel/ncc from 0.23.0 to 0.24.0 [#2](https://github.com/yuta1024/cards-moving-automation/pull/2) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))

### Security
- [Security] Bump node-fetch from 2.6.0 to 2.6.1 [#8](https://github.com/yuta1024/cards-moving-automation/pull/8) ([dependabot-preview](https://github.com/marketplace/dependabot-preview))